### PR TITLE
Typo fixes and make SpamClient#report work properly

### DIFF
--- a/lib/RubySpamAssassin.rb
+++ b/lib/RubySpamAssassin.rb
@@ -27,28 +27,29 @@ module RubySpamAssassin
       @port = port
       @host = host
       @timeout =timeout
-      @socket = TCPsocket.open(@host, @port)
+      @socket = TCPSocket.open(@host, @port)
     end
 
     def reconnect
-      @socket = @socket || TCPsocket.open(@host, @port)
+      @socket = @socket || TCPSocket.open(@host, @port)
     end
 
     def send_symbol(message)
-      protocol_repsonse = send_message("SYMBOLS", message)
-      result = process_headers(SpamResult.new, protocol_repsonse[0...2])
-      result.tags = protocol_repsonse[3...-1].join(" ").split(',')
+      protocol_response = send_message("SYMBOLS", message)
+      result = process_headers(SpamResult.new, protocol_response[0...2])
+      result.tags = protocol_response[3...-1].join(" ").split(',')
     end
 
     def check(message)
-      protocol_repsonse = send_message("CHECK", message)
-      result = process_headers(SpamResult.new, protocol_repsonse[0...2])
+      protocol_response = send_message("CHECK", message)
+      result = process_headers(SpamResult.new, protocol_response[0...2])
     end
 
     def report(message)
       protocol_response = send_message("REPORT", message)
-      result = process_headers(SpamResult.new, protocol_repsonse[0...2])
+      result = process_headers(SpamResult.new, protocol_response[0...2])
       result.report = protocol_response[3..-1].join
+      result
     end
 
     def report_ifspam(message)
@@ -61,7 +62,7 @@ module RubySpamAssassin
 
     def ping
       protocol_response = send_message("PING", message)
-      result = process_headers(SpamResult.new, protocol_repsonse[0])
+      result = process_headers(SpamResult.new, protocol_response[0])
     end
 
     alias :process :report
@@ -94,6 +95,7 @@ module RubySpamAssassin
             result.content_length = $1
         end
       end
+      result
     end
   end
 end


### PR DESCRIPTION
`TCPsocket` wanted to be `TCPSocket` in my world, and protocol_re`ps`onse didn't work as well as protocol_re`sp`onse to make #report work
