### PR TITLE
Use bytesize to cater for extended character sets

### DIFF
--- a/lib/RubySpamAssassin/spam_client.rb
+++ b/lib/RubySpamAssassin/spam_client.rb
@@ -49,7 +49,7 @@ class RubySpamAssassin::SpamClient
 
   private
   def send_message(command, message)
-    length = message.length
+    length = message.bytesize
     @socket.write(command + " SPAMC/1.2\r\n")
     @socket.write("Content-length: " + length.to_s + "\r\n\r\n")
     @socket.write(message)


### PR DESCRIPTION
Often the spam messages we're scanning contain extended characters (multibyte) so bytesize gives a more accurate length of the string.  For example â and € 
