### PR TITLE
New connection per request and small fixes for commands without message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec", "~> 2.3.0"
+  gem "rspec"
   gem "bundler" # , "~> 1.0.0"
   gem "jeweler" # , "~> 1.5.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.5)
     git (1.2.5)
     jeweler (1.8.4)
       bundler (~> 1.0)
@@ -12,14 +12,19 @@ GEM
     rake (10.0.3)
     rdoc (3.12)
       json (~> 1.4)
-    rspec (2.3.0)
-      rspec-core (~> 2.3.0)
-      rspec-expectations (~> 2.3.0)
-      rspec-mocks (~> 2.3.0)
-    rspec-core (2.3.1)
-    rspec-expectations (2.3.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.3.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.0)
 
 PLATFORMS
   ruby
@@ -27,4 +32,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   jeweler
-  rspec (~> 2.3.0)
+  rspec
+
+BUNDLED WITH
+   1.10.6

--- a/lib/RubySpamAssassin/spam_client.rb
+++ b/lib/RubySpamAssassin/spam_client.rb
@@ -37,18 +37,18 @@ class RubySpamAssassin::SpamClient
   end
 
   def skip
-    protocol_response = send_message("SKIP", message)
+    protocol_response = send_message("SKIP")
   end
 
   def ping
-    protocol_response = send_message("PING", message)
+    protocol_response = send_message("PING")
     result = process_headers protocol_response[0]
   end
 
   alias :process :report
 
   private
-  def send_message(command, message)
+  def send_message(command, message = "")
     length = message.bytesize
     @socket.write(command + " SPAMC/1.2\r\n")
     @socket.write("Content-length: " + length.to_s + "\r\n\r\n")

--- a/lib/single_connection_pool.rb
+++ b/lib/single_connection_pool.rb
@@ -1,0 +1,17 @@
+class SingleConnectionPool
+  DEFAULTS = {}
+  
+  def initialize(options = {})
+    @options = DEFAULTS.merge(options)
+  end
+
+  def with(options = {})
+    options = @options.merge(options)
+    host = options.fetch(:host)
+    port = options.fetch(:port)
+    socket = TCPSocket.open(host, port)
+    yield socket
+  ensure
+    socket.close rescue nil
+  end
+end

--- a/spec/RubySpamAssassin/spam_client_spec.rb
+++ b/spec/RubySpamAssassin/spam_client_spec.rb
@@ -1,1 +1,30 @@
 require_relative '../spec_helper'
+
+describe RubySpamAssassin::SpamClient do
+  it "does not open a socket at initialization" do
+    expect(TCPSocket).not_to receive(:open)
+    RubySpamAssassin::SpamClient.new
+  end
+
+  describe "#send" do
+    let(:socket) { instance_double("TCPSocket", readlines: [[]]).as_null_object }
+
+    it "opens a socket on every request" do
+      expect(TCPSocket).to receive(:open).and_return(socket)
+      subject.ping
+    end
+
+    it "closes the socket on every request" do
+      allow(TCPSocket).to receive(:open).and_return(socket)
+      expect(socket).to receive(:close)
+      subject.ping
+    end
+
+    it "even closes the socket in case of an exception during the request" do
+      allow(TCPSocket).to receive(:open).and_return(socket)
+      allow(socket).to receive(:write).and_raise("Some error")
+      expect(socket).to receive(:close)
+      expect { subject.ping }.to raise_error "Some error"
+    end
+  end
+end


### PR DESCRIPTION
In order to easily change connection strategies I factored the socket out to a separate connection pool object, for now with only a single connection which is opened and closed again for every request. I had troubles connecting to a (dockered) local spamassassin instance using the original implementation - the service kept hanging after a first successful classification.

The fixes for the message-less skip and ping commands are in a separate commit.