### PR TITLE
Added support for TELL command

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -7,14 +7,25 @@ Now you just need to:
     include RubySpamAssassin
 
     spam_client = SpamClient.new("host_running_spamd", "port_spamd_is_listening_on", timeout)
-    # MyMailer is your ActionMailer
-    # check will also accept a string, if you're into that kind of thing
-    report = spam_client.check(MyMailer.my_email.to_s)
+    message = File.read("/path/to/email.eml")
+
+    report = spam_client.check(message)
     p report.inspect
 
 Wasn't that easy?
 
 Cucumber and rspec tests are on their way.
+
+== Using TELL command
+
+To learn a message as spam:
+    spam_client.tell(message, message_class: "spam", set: "local")
+To learn a message as ham:
+    spam_client.tell(message, message_class: "ham", set: "local")
+To forget a learned message:
+    spam_client.tell(message, remove: "local")
+You can also set username of the user on whose behalf this scan is being performed:
+    spam_client.tell(message, message_class: "spam", set: "local", user: "johndoe")
 
 == Contributing to RubySpamAssassin
  
@@ -29,4 +40,3 @@ Cucumber and rspec tests are on their way.
 == Copyright
 
 Copyright (c) 2011 Kevin Poorman. See LICENSE.txt for further details.
-

--- a/lib/RubySpamAssassin/spam_client.rb
+++ b/lib/RubySpamAssassin/spam_client.rb
@@ -17,6 +17,15 @@ class RubySpamAssassin::SpamClient
     result = process_headers protocol_response[0...2]
   end
 
+  def tell(message, message_class, set=true, user=nil)
+    headers = []
+    headers.push("Message-class: #{message_class}")
+    headers.push(set ? "Set: local" : "Remove: local")
+    headers.push("User: #{user}") if !user.nil?
+    protocol_response = send_message("TELL", message, headers)
+    result = process_headers protocol_response[0...2]
+  end
+
   def report(message)
     protocol_response = send_message("REPORT", message)
     result = process_headers protocol_response[0...2]
@@ -41,10 +50,14 @@ class RubySpamAssassin::SpamClient
   alias :process :report
 
   private
-  def send_message(command, message = "")
+
+  def send_message(command, message="", headers=[])
     length = message.bytesize
     @connection_pool.with do |socket|
       socket.write(command + " SPAMC/1.2\r\n")
+      headers.each do |h|
+        socket.write(h + "\r\n")
+      end
       socket.write("Content-length: " + length.to_s + "\r\n\r\n")
       socket.write(message)
       socket.shutdown(1) #have to shutdown sending side to get response

--- a/lib/RubySpamAssassin/spam_client.rb
+++ b/lib/RubySpamAssassin/spam_client.rb
@@ -17,12 +17,13 @@ class RubySpamAssassin::SpamClient
     result = process_headers protocol_response[0...2]
   end
 
-  def tell(message, message_class, set=true, user=nil)
-    headers = []
-    headers.push("Message-class: #{message_class}")
-    headers.push(set ? "Set: local" : "Remove: local")
-    headers.push("User: #{user}") if !user.nil?
-    protocol_response = send_message("TELL", message, headers)
+  def tell(message, headers={})
+    h = []
+    h << "Message-class: #{headers[:message_class]}" if headers[:message_class]
+    h << "Set: #{headers[:set]}" if headers[:set]
+    h << "Remove: #{headers[:remove]}" if headers[:remove]
+    h << "User: #{headers[:user]}" if headers[:user]
+    protocol_response = send_message("TELL", message, h)
     result = process_headers protocol_response[0...2]
   end
 


### PR DESCRIPTION
You can now use spam_client.tell method for making a TELL command. This includes setting or removing a local or a remote database (learning, reporting, forgetting, revoking). You can also set a user ID/name. Code is tested on production environment and It's fully working.