### PR TITLE
Fix rule texts parsing

### DIFF
--- a/lib/RubySpamAssassin/report_parser.rb
+++ b/lib/RubySpamAssassin/report_parser.rb
@@ -5,7 +5,7 @@ class RubySpamAssassin::ReportParser
   def self.parse(report_text)
     last_part = report_text.split(LINE_REGEXP)[1].sub(/^[\n\r]/,'').chomp.chomp
     pts_rules = last_part.gsub(RULE_REGEXP).collect { |sub| sub.chomp(' ') }
-    rule_texts = last_part.split(RULE_REGEXP).collect { |text| text.delete("\n").squeeze.chomp(' ').sub(/^\s/, '') }
+    rule_texts = last_part.split(RULE_REGEXP).collect { |text| text.delete("\n").squeeze(' ').strip }
 
     rules = []
     pts_rules.each_with_index do |pts_rule, i|

--- a/spec/RubySpamAssassin/report_parser_spec.rb
+++ b/spec/RubySpamAssassin/report_parser_spec.rb
@@ -6,9 +6,13 @@ describe "ReportParser" do
     result = RubySpamAssassin::ReportParser.parse(spam)
     expect(result.length).to eq(6)
 
-    # Check contents of first one to make sure text/points are formatted correctly
+    # Check contents of some rules to make sure text/points are formatted correctly
     expect(result[0][:pts]).to eq(0.5)
     expect(result[0][:rule]).to eq('DATE_IN_PAST_24_48')
     expect(result[0][:text]).to eq('Date: is 24 to 48 hours before Received: date')
+
+    expect(result[4][:pts]).to eq(1.2)
+    expect(result[4][:rule]).to eq('INVALID_MSGID')
+    expect(result[4][:text]).to eq('Message-Id is not valid, according to RFC 2822')
   end
 end

--- a/spec/RubySpamAssassin/report_parser_spec.rb
+++ b/spec/RubySpamAssassin/report_parser_spec.rb
@@ -4,11 +4,11 @@ describe "ReportParser" do
   it "should parse the report text into an informative hash" do
     spam = File.read('spec/data/spam_test1.txt')
     result = RubySpamAssassin::ReportParser.parse(spam)
-    result.length.equal?(6)
+    expect(result.length).to eq(6)
 
     # Check contents of first one to make sure text/points are formatted correctly
-    result[0][:pts].equal?(0.5)
-    result[0][:rule].equal?('DATE_IN_PAST_24_48')
-    result[0][:text].equal?('Date: is 24 to 48 hours before Received: date')
+    expect(result[0][:pts]).to eq(0.5)
+    expect(result[0][:rule]).to eq('DATE_IN_PAST_24_48')
+    expect(result[0][:text]).to eq('Date: is 24 to 48 hours before Received: date')
   end
 end


### PR DESCRIPTION
It was using squeeze method without any parameter which will squeeze all characters.

Texts like

> Message-Id is not valid, according to RFC 2822

were parsed as 

> Mesage-Id is not valid, acording to RFC 282

Note that Message-Id was changed to Mesage-Id and RFC 2822 was changed to RFC 282.

As a bonus I corrected the tests in https://github.com/codefriar/RubySpamAssassin/blob/af6d81bdfe0a1438a1911f46d68b1ec3a5e262b6/spec/RubySpamAssassin/report_parser_spec.rb which weren't testing anything since they didn't used expect() method.